### PR TITLE
删除21.3节示例代码中重复且易造成歧义的部分

### DIFF
--- a/Vulkan编程指南.tex
+++ b/Vulkan编程指南.tex
@@ -4596,11 +4596,6 @@ return;
 } else if (result != VK_SUCCESS && result != VK_SUBOPTIMAL_KHR) {
 throw std::runtime_error("failed to acquire swap chain image!");
 }
-recreateSwapChain();
-return;
-} else if (result != VK_SUCCESS && result != VK_SUBOPTIMAL_KHR) {
-throw std::runtime_error("failed to acquire swap chain image!");
-}
 \end{lstlisting}
 
 当交换链过期时，我们就不能再使用它，必须重建交换链。


### PR DESCRIPTION
来自Issue #15 的代码示例错误，删除掉TeX中重复的部分，不过软件兼容性问题自己的电脑无法生成完整的PDF，故只能提交修改后的 ```.tex``` 文件。
其中英文原版中关于求无符号长整型的方法目前已经是使用宏 ```UINT64_MAX``` 来表示，不过由于教程里窗口服务使用的是glfw，在Windows环境下应该不会和windows.h内的宏 ```max(a, b)``` 产生重定义导致的编译问题。故这里保留译者的```std::numeric_limits<uint64t>::max()```。